### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,10 +128,12 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
+        
         <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
 
+        <% @items.each do |item| %>
+        <div class='item-img-content'>
+          <%= image_tag  item.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -141,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,11 +154,13 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,6 +178,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>


### PR DESCRIPTION
# What
商品一覧表示機能を実装した

# Why
furimaアプリの作成に投稿した商品の一覧表示機能が必要なため

商品一覧表示
https://gyazo.com/9ca96ad1fea01ea402e3d9e855e2f4e1

画像がリンク切れになっていないこと
https://gyazo.com/5828c7d9ddadcedd6c1300712b43a2f2

ログアウト状態のユーザーでも商品一覧が表示できていること
https://gyazo.com/5828c7d9ddadcedd6c1300712b43a2f2

sold out機能については商品購入機能実装時にて追加します。
